### PR TITLE
Update for leaving the USU

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@ The full documentation for the API can be found [here](https://apidocs.suits.org
 To get this running locally...
 
 - Have MySQL installed (don't use sqlite because it doesn't have good support for foreign key constraints).
-- Create a database called `api` specifically for this api.
-- Create a database user with permissions on that database.
+- Create a database called `api` specifically for this api. And create a database user with permissions on that database, e.g.:
+```sql
+create database api;
+create user api@localhost identified by 'cats';
+grant all privileges on api.* to `api`@`localhost`;
+```
+- Ensure that the database is running.
 - Copy `config.example.json` to `config.json`, and `ormconfig.example.json` to `ormconfig.json` and update them as appropriate.
+    - Sentry DSN (you can just delete it)
+    - Database details
+    - If you want the database to create / update tables (say, because you are creating it for the first time) you should set `"synchronize": true`, though, apparently this should not be used in production.
 - Run `npm install`
+- Run `npm run build`
+- Run `npm start`
 
 To check your database connection:
     - `mysql -u dbuser -p`

--- a/src/api/members/members.dto.ts
+++ b/src/api/members/members.dto.ts
@@ -32,13 +32,7 @@ export class MemberDto implements IMember {
     @IsOptional()
     public joinedOn?: Date;
 
-    @ApiPropertyOptional()
-    @IsOptional()
-    @IsInt()
-    public access?: number;
-
-    @ApiPropertyOptional()
-    @IsOptional()
+    @ApiProperty()
     @IsInt()
     public sid?: number;
 

--- a/src/api/members/members.service.ts
+++ b/src/api/members/members.service.ts
@@ -8,7 +8,7 @@ import { MemberDto } from "./members.dto";
 
 @Injectable()
 export class MembersService {
-    private FIND_MEMBER = ["email", "sid", "access"]
+    private FIND_MEMBER = ["email", "sid"]
         .map(f => `(member.${f} IS NOT NULL AND member.${f} = :${f})`)
         .join(" OR ");
 
@@ -80,14 +80,13 @@ export class MembersService {
     private async getMemberIfExists(
         data: MemberDto,
     ): Promise<MemberEntity | undefined> {
-        const validVals = [data.email, data.access, data.sid].filter(v => v);
+        const validVals = [data.email, data.sid].filter(v => v);
         if (validVals.length != 0) {
             let q = this.repo.createQueryBuilder("member");
             q = q.select();
 
             // At least one will be not null. Pass through null otherwise.
             q = q.where(this.FIND_MEMBER, {
-                access: data.access,
                 email: data.email,
                 sid: data.sid,
             });


### PR DESCRIPTION
- Improve the README, because this is only, like, the second time I have
  run the API properly locally...
- Remove access as a property on the API input (but not the entity, so
  that we can keep the historical record on the database).
- Make SID required on the API input.
- Don't check for access matches when trying to see if a user already
  exists.

This should be deployed together with the corresponding join form
update.

This doesn't require an update to the events API, new memebers will just
show up without access. Eventually though access number should
eventually be replaced with SID on there.